### PR TITLE
Docker script for mac m chip with uncommon ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,182 @@
+# n8n Docker 环境变量配置示例 - Mac M芯片专用
+# 复制此文件为 .env 并根据需要修改配置
+
+# ===========================================
+# 基础配置
+# ===========================================
+
+# n8n 访问端口 (对外端口)
+N8N_PORT=8967
+
+# n8n 主机地址 (通常保持默认)
+N8N_HOST=0.0.0.0
+
+# n8n 协议 (http 或 https)
+N8N_PROTOCOL=http
+
+# Webhook URL (用于接收外部Webhook)
+WEBHOOK_URL=http://localhost:8967
+
+# 时区设置
+GENERIC_TIMEZONE=Asia/Shanghai
+
+# ===========================================
+# 数据库配置 (完整方案)
+# ===========================================
+
+# PostgreSQL 配置
+POSTGRES_DB=n8n
+POSTGRES_USER=n8n_user
+POSTGRES_PASSWORD=n8n_secure_password_2024
+
+# 数据库连接配置
+DB_TYPE=postgresdb
+DB_POSTGRESDB_HOST=postgres
+DB_POSTGRESDB_PORT=5432
+DB_POSTGRESDB_DATABASE=n8n
+DB_POSTGRESDB_USER=n8n_user
+DB_POSTGRESDB_PASSWORD=n8n_secure_password_2024
+DB_POSTGRESDB_SCHEMA=public
+
+# ===========================================
+# Redis 配置 (完整方案)
+# ===========================================
+
+# Redis 密码
+REDIS_PASSWORD=redis_secure_password_2024
+
+# Redis 连接配置
+QUEUE_BULL_REDIS_HOST=redis
+QUEUE_BULL_REDIS_PORT=6379
+QUEUE_BULL_REDIS_PASSWORD=redis_secure_password_2024
+
+# 执行模式 (regular 或 queue)
+EXECUTIONS_MODE=queue
+
+# ===========================================
+# 安全配置
+# ===========================================
+
+# 是否启用安全Cookie (https环境下设为true)
+N8N_SECURE_COOKIE=false
+
+# 是否启用度量指标
+N8N_METRICS=true
+
+# 是否启用诊断数据收集
+N8N_DIAGNOSTICS_ENABLED=false
+
+# 加密密钥 (生产环境请设置复杂密钥)
+# N8N_ENCRYPTION_KEY=your_encryption_key_here
+
+# ===========================================
+# 性能配置
+# ===========================================
+
+# 生产环境并发限制
+N8N_CONCURRENCY_PRODUCTION_LIMIT=10
+
+# 工作流执行数据保留天数
+EXECUTIONS_DATA_MAX_AGE=168
+
+# 是否启用执行数据清理
+EXECUTIONS_DATA_PRUNE=true
+
+# SQLite 配置 (单容器方案)
+DB_SQLITE_ENABLE_WAL=true
+DB_SQLITE_VACUUM_ON_STARTUP=true
+DB_SQLITE_POOL_SIZE=3
+
+# ===========================================
+# Task Runner 配置
+# ===========================================
+
+# 是否启用 Task Runner
+N8N_RUNNERS_ENABLED=true
+
+# Task Runner 模式 (internal 或 external)
+N8N_RUNNERS_MODE=internal
+
+# ===========================================
+# 日志配置
+# ===========================================
+
+# 日志级别 (error, warn, info, debug)
+N8N_LOG_LEVEL=info
+
+# 日志输出方式 (console, file)
+N8N_LOG_OUTPUT=console
+
+# ===========================================
+# 邮件配置 (可选)
+# ===========================================
+
+# 邮件发送模式 (smtp)
+# N8N_EMAIL_MODE=smtp
+
+# SMTP 服务器配置
+# N8N_SMTP_HOST=smtp.gmail.com
+# N8N_SMTP_PORT=587
+# N8N_SMTP_USER=your-email@gmail.com
+# N8N_SMTP_PASS=your-app-password
+# N8N_SMTP_SENDER=your-email@gmail.com
+# N8N_SMTP_SSL=true
+
+# ===========================================
+# 高级配置
+# ===========================================
+
+# 是否启用代理跳数检测
+# N8N_PROXY_HOPS=1
+
+# 多主节点设置 (集群环境)
+# N8N_MULTI_MAIN_SETUP_ENABLED=false
+
+# 禁用的模块
+# N8N_DISABLED_MODULES=insights
+
+# 启用的模块
+# N8N_ENABLED_MODULES=insights
+
+# 队列健康检查
+# QUEUE_HEALTH_CHECK_ACTIVE=true
+
+# ===========================================
+# Docker 配置
+# ===========================================
+
+# Docker 项目名称
+COMPOSE_PROJECT_NAME=n8n-mac-m1
+
+# Docker 网络子网
+DOCKER_SUBNET=172.20.0.0/16
+
+# ===========================================
+# 备份配置
+# ===========================================
+
+# 备份保留天数
+BACKUP_RETENTION_DAYS=30
+
+# 备份目录
+BACKUP_DIR=./backups
+
+# 是否启用自动备份
+AUTO_BACKUP_ENABLED=true
+
+# 自动备份间隔 (小时)
+AUTO_BACKUP_INTERVAL=24
+
+# ===========================================
+# 使用说明
+# ===========================================
+
+# 1. 复制此文件为 .env: cp .env.example .env
+# 2. 根据需要修改配置值
+# 3. 重启服务使配置生效
+
+# 注意事项:
+# - 生产环境请务必修改默认密码
+# - 建议为每个环境使用不同的加密密钥
+# - HTTPS 环境下请启用 N8N_SECURE_COOKIE
+# - 根据服务器性能调整并发限制

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -1,0 +1,149 @@
+# 🚀 n8n Docker 快速入门 - Mac M芯片专用
+
+## 📁 文件说明
+
+```
+📦 n8n-docker-mac-m1/
+├── 🎯 start-n8n.sh               # 交互式启动器 (推荐)
+├── 🏃 run-n8n-mac-m1.sh          # 单容器部署脚本
+├── 🏢 manage-n8n.sh              # 完整方案管理脚本
+├── 📋 docker-compose-mac-m1.yml  # Docker Compose 配置
+├── 🔧 .env.example               # 环境变量示例
+├── 📖 README-Mac-M1-Docker.md    # 详细文档
+└── 📝 QUICK-START.md            # 本文件
+```
+
+## ⚡ 快速开始
+
+### 方法一：交互式启动器（推荐新手）
+```bash
+./start-n8n.sh
+```
+- 提供图形化菜单选择
+- 自动检查系统要求
+- 支持两种部署方案
+
+### 方法二：直接运行简单方案
+```bash
+./run-n8n-mac-m1.sh
+```
+- 单容器 + SQLite
+- 快速启动，适合个人使用
+
+### 方法三：直接运行完整方案
+```bash
+./manage-n8n.sh start
+```
+- 多容器 + PostgreSQL + Redis
+- 生产级别，支持高并发
+
+## 🎯 访问地址
+
+所有方案统一使用：**http://localhost:8967**
+
+## 📊 方案对比
+
+| 特性 | 简单方案 | 完整方案 |
+|------|----------|----------|
+| 启动命令 | `./run-n8n-mac-m1.sh` | `./manage-n8n.sh start` |
+| 数据库 | SQLite | PostgreSQL |
+| 缓存 | 无 | Redis |
+| 扩展性 | 有限 | 高 |
+| 适用场景 | 个人/测试 | 生产/团队 |
+
+## 🛠️ 常用命令
+
+### 简单方案
+```bash
+# 查看状态
+docker ps
+
+# 查看日志
+docker logs n8n-workflow
+
+# 停止服务
+docker stop n8n-workflow
+
+# 重启服务
+docker restart n8n-workflow
+```
+
+### 完整方案
+```bash
+# 查看所有命令
+./manage-n8n.sh help
+
+# 启动服务
+./manage-n8n.sh start
+
+# 查看状态
+./manage-n8n.sh status
+
+# 查看日志
+./manage-n8n.sh logs
+
+# 备份数据
+./manage-n8n.sh backup
+
+# 停止服务
+./manage-n8n.sh stop
+```
+
+## ⚙️ 自定义配置
+
+1. **复制环境变量文件**：
+   ```bash
+   cp .env.example .env
+   ```
+
+2. **编辑配置**：
+   ```bash
+   nano .env
+   ```
+
+3. **重启服务使配置生效**
+
+## 🔧 常见问题
+
+### Q: 首次启动很慢？
+A: 需要下载Docker镜像，请耐心等待3-5分钟
+
+### Q: 端口8967被占用？
+A: 修改脚本中的端口号，或在.env文件中设置
+
+### Q: 数据存储在哪里？
+A: 
+- 简单方案：`./n8n-data/` 目录
+- 完整方案：Docker卷 (持久化存储)
+
+### Q: 如何备份数据？
+A: 
+- 简单方案：备份 `./n8n-data/` 目录
+- 完整方案：使用 `./manage-n8n.sh backup`
+
+## 🎨 特色功能
+
+✅ **Mac M芯片优化** - 专为ARM64架构设计  
+✅ **不常见端口** - 使用8967端口避免冲突  
+✅ **一键启动** - 简单命令即可运行  
+✅ **数据持久化** - 重启不丢失数据  
+✅ **自动备份** - 完整方案支持数据备份  
+✅ **健康检查** - 自动监控服务状态  
+✅ **中文支持** - 全中文界面和文档  
+
+## 🚨 注意事项
+
+- 确保Docker Desktop已启动
+- 首次运行会下载镜像，需要网络连接
+- 生产环境请修改默认密码
+- 建议定期备份重要数据
+
+## 📚 更多帮助
+
+- 详细文档：`README-Mac-M1-Docker.md`
+- 环境变量：`.env.example`
+- 在线帮助：`./manage-n8n.sh help`
+
+---
+
+**快速体验**：直接运行 `./start-n8n.sh` 开始您的n8n之旅！ 🎉

--- a/README-Mac-M1-Docker.md
+++ b/README-Mac-M1-Docker.md
@@ -1,0 +1,349 @@
+# n8n Docker 部署指南 - Mac M芯片专用
+
+本指南提供了在Mac M芯片（Apple Silicon）上运行n8n的完整Docker解决方案，使用不常见端口**8967**以避免端口冲突。
+
+## 📋 目录
+
+- [前置要求](#前置要求)
+- [快速开始](#快速开始)
+- [部署方案](#部署方案)
+- [详细使用指南](#详细使用指南)
+- [配置说明](#配置说明)
+- [常见问题](#常见问题)
+- [维护操作](#维护操作)
+- [安全建议](#安全建议)
+
+## 🔧 前置要求
+
+### 系统要求
+- macOS 11.0+ (Big Sur)
+- Apple Silicon (M1/M2/M3) 芯片
+- 至少 4GB 可用内存
+- 至少 10GB 可用磁盘空间
+
+### 软件要求
+- [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/) (推荐最新版本)
+- Docker Compose (通常包含在Docker Desktop中)
+
+### 验证安装
+```bash
+# 检查Docker版本
+docker --version
+
+# 检查Docker Compose版本
+docker compose version
+
+# 检查系统架构
+uname -m  # 应显示 arm64
+```
+
+## 🚀 快速开始
+
+### 方案一：简单单容器部署（推荐新手）
+
+1. **下载并运行单容器脚本**：
+   ```bash
+   # 添加执行权限
+   chmod +x run-n8n-mac-m1.sh
+   
+   # 启动n8n
+   ./run-n8n-mac-m1.sh
+   ```
+
+2. **访问n8n**：
+   打开浏览器访问 `http://localhost:8967`
+
+### 方案二：完整生产环境部署（推荐生产使用）
+
+1. **使用管理脚本启动**：
+   ```bash
+   # 添加执行权限
+   chmod +x manage-n8n.sh
+   
+   # 启动完整服务栈
+   ./manage-n8n.sh start
+   ```
+
+2. **访问n8n**：
+   打开浏览器访问 `http://localhost:8967`
+
+## 📚 部署方案
+
+### 方案对比
+
+| 特性 | 单容器方案 | 完整方案 |
+|------|------------|----------|
+| 数据库 | SQLite | PostgreSQL |
+| 缓存 | 无 | Redis |
+| 扩展性 | 有限 | 高 |
+| 资源占用 | 低 | 中等 |
+| 适用场景 | 个人使用/测试 | 生产环境/团队使用 |
+| Worker支持 | 无 | 支持 |
+| 队列模式 | 无 | 支持 |
+
+### 文件说明
+
+```
+.
+├── run-n8n-mac-m1.sh           # 单容器启动脚本
+├── docker-compose-mac-m1.yml   # 完整Docker Compose配置
+├── manage-n8n.sh               # 服务管理脚本
+├── README-Mac-M1-Docker.md     # 本文档
+├── n8n-data/                   # n8n数据目录（自动创建）
+├── backups/                    # 数据库备份目录（自动创建）
+├── custom-nodes/               # 自定义节点目录（自动创建）
+└── workflows/                  # 工作流备份目录（自动创建）
+```
+
+## 📖 详细使用指南
+
+### 单容器方案使用
+
+```bash
+# 启动服务
+./run-n8n-mac-m1.sh
+
+# 查看容器状态
+docker ps
+
+# 查看日志
+docker logs n8n-workflow
+
+# 停止服务
+docker stop n8n-workflow
+
+# 重启服务
+docker restart n8n-workflow
+```
+
+### 完整方案使用
+
+管理脚本提供了丰富的命令：
+
+```bash
+# 查看所有可用命令
+./manage-n8n.sh help
+
+# 启动所有服务
+./manage-n8n.sh start
+
+# 查看服务状态
+./manage-n8n.sh status
+
+# 查看实时日志
+./manage-n8n.sh logs
+
+# 只查看n8n日志
+./manage-n8n.sh logs-n8n
+
+# 备份数据库
+./manage-n8n.sh backup
+
+# 更新到最新版本
+./manage-n8n.sh update
+
+# 停止所有服务
+./manage-n8n.sh stop
+```
+
+### 高级操作
+
+```bash
+# 进入n8n容器shell
+./manage-n8n.sh shell
+
+# 连接PostgreSQL数据库
+./manage-n8n.sh psql
+
+# 连接Redis
+./manage-n8n.sh redis
+
+# 显示系统信息
+./manage-n8n.sh info
+```
+
+## ⚙️ 配置说明
+
+### 端口配置
+- **主端口**: 8967 (n8n Web界面)
+- **内部端口**: 5678 (容器内部)
+
+### 环境变量配置
+
+主要环境变量可在相应配置文件中修改：
+
+```yaml
+# 基础配置
+N8N_HOST: 0.0.0.0
+N8N_PORT: 5678
+N8N_PROTOCOL: http
+WEBHOOK_URL: http://localhost:8967
+GENERIC_TIMEZONE: Asia/Shanghai
+
+# 数据库配置（完整方案）
+DB_TYPE: postgresdb
+DB_POSTGRESDB_HOST: postgres
+DB_POSTGRESDB_DATABASE: n8n
+DB_POSTGRESDB_USER: n8n_user
+DB_POSTGRESDB_PASSWORD: n8n_secure_password_2024
+
+# 性能配置
+N8N_CONCURRENCY_PRODUCTION_LIMIT: 10
+EXECUTIONS_DATA_MAX_AGE: 168  # 7天
+```
+
+### 数据持久化
+
+- **单容器方案**: 数据存储在 `./n8n-data` 目录
+- **完整方案**: 使用Docker卷持久化数据
+  - PostgreSQL 数据
+  - Redis 数据
+  - n8n 配置和工作流
+
+## 🔍 常见问题
+
+### Q: 首次启动很慢怎么办？
+A: 首次启动需要下载镜像和初始化数据库，请耐心等待3-5分钟。
+
+### Q: 8967端口被占用怎么办？
+A: 修改脚本中的`HOST_PORT`变量为其他端口，如8968、9234等。
+
+### Q: 如何更改时区？
+A: 修改环境变量`GENERIC_TIMEZONE`，如改为`America/New_York`。
+
+### Q: 如何添加自定义节点？
+A: 将节点文件放入`custom-nodes`目录，重启服务即可。
+
+### Q: 数据如何备份？
+A: 使用 `./manage-n8n.sh backup` 命令自动备份PostgreSQL数据库。
+
+### Q: 如何恢复数据？
+A: 使用 `./manage-n8n.sh restore` 命令从备份文件恢复。
+
+### Q: 服务无法启动怎么办？
+A: 检查Docker是否运行，查看日志：`./manage-n8n.sh logs`
+
+### Q: 如何升级n8n版本？
+A: 使用 `./manage-n8n.sh update` 命令自动升级到最新版本。
+
+## 🛠️ 维护操作
+
+### 定期维护任务
+
+1. **数据备份**（建议每周）：
+   ```bash
+   ./manage-n8n.sh backup
+   ```
+
+2. **日志清理**（建议每月）：
+   ```bash
+   docker system prune -f
+   ```
+
+3. **版本更新**（建议每月检查）：
+   ```bash
+   ./manage-n8n.sh update
+   ```
+
+### 监控和调试
+
+```bash
+# 查看资源使用情况
+./manage-n8n.sh status
+
+# 实时查看日志
+./manage-n8n.sh logs
+
+# 检查容器健康状态
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+```
+
+### 性能优化
+
+1. **调整并发限制**：
+   - 修改 `N8N_CONCURRENCY_PRODUCTION_LIMIT` 环境变量
+   - 根据Mac性能调整，建议M1/M2为10-20
+
+2. **数据清理**：
+   - 设置 `EXECUTIONS_DATA_MAX_AGE` 自动清理旧执行记录
+   - 定期清理不需要的工作流
+
+3. **内存优化**：
+   - 监控Docker Desktop内存使用
+   - 必要时调整Docker内存限制
+
+## 🔒 安全建议
+
+### 生产环境安全配置
+
+1. **更改默认密码**：
+   ```yaml
+   # 在docker-compose-mac-m1.yml中修改
+   POSTGRES_PASSWORD: your_secure_password
+   QUEUE_BULL_REDIS_PASSWORD: your_redis_password
+   ```
+
+2. **启用HTTPS**（生产环境）：
+   ```yaml
+   N8N_PROTOCOL: https
+   N8N_SECURE_COOKIE: true
+   ```
+
+3. **限制网络访问**：
+   - 仅在必要时开放端口
+   - 使用防火墙限制访问
+
+4. **定期备份**：
+   - 设置自动备份任务
+   - 将备份存储在安全位置
+
+### 网络安全
+
+- 使用强密码
+- 定期更新n8n版本  
+- 监控访问日志
+- 限制管理员权限
+
+## 📞 支持和帮助
+
+### 获取帮助
+
+1. **查看脚本帮助**：
+   ```bash
+   ./manage-n8n.sh help
+   ```
+
+2. **查看官方文档**：
+   - [n8n官方文档](https://docs.n8n.io/)
+   - [Docker官方文档](https://docs.docker.com/)
+
+3. **社区支持**：
+   - [n8n社区论坛](https://community.n8n.io/)
+   - [GitHub Issues](https://github.com/n8n-io/n8n/issues)
+
+### 日志收集
+
+如需技术支持，请提供以下信息：
+
+```bash
+# 系统信息
+./manage-n8n.sh info
+
+# 服务状态
+./manage-n8n.sh status
+
+# 错误日志
+./manage-n8n.sh logs > n8n-logs.txt
+```
+
+## 📝 更新日志
+
+- **v1.0.0** - 初始版本，支持Mac M芯片
+- 使用端口8967避免冲突
+- 支持单容器和完整部署方案
+- 提供完整的管理脚本
+- 针对ARM64架构优化
+
+---
+
+**注意**: 本指南专为Mac M芯片设计，确保Docker Desktop已正确配置ARM64支持。如有问题，请检查Docker设置中的"Use Rosetta for x86/amd64 emulation"选项。

--- a/docker-compose-mac-m1.yml
+++ b/docker-compose-mac-m1.yml
@@ -1,0 +1,191 @@
+version: '3.8'
+
+# n8n Docker Compose 配置 - Mac M芯片专用
+# 使用端口: 8967 (不常见端口)
+# 包含: n8n + PostgreSQL + Redis (可选)
+
+services:
+  # PostgreSQL 数据库
+  postgres:
+    image: postgres:16-alpine
+    platform: linux/arm64
+    container_name: n8n-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: n8n
+      POSTGRES_USER: n8n_user
+      POSTGRES_PASSWORD: n8n_secure_password_2024
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./backups:/backups  # 备份目录
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U n8n_user -d n8n']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - n8n_network
+
+  # Redis (可选 - 用于队列和缓存)
+  redis:
+    image: redis:7-alpine
+    platform: linux/arm64
+    container_name: n8n-redis
+    restart: unless-stopped
+    command: redis-server --requirepass redis_secure_password_2024
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', '--no-auth-warning', '-a', 'redis_secure_password_2024', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - n8n_network
+
+  # n8n 主服务
+  n8n:
+    image: n8nio/n8n:latest
+    platform: linux/arm64
+    container_name: n8n-main
+    restart: unless-stopped
+    ports:
+      - "8967:5678"  # 使用不常见端口 8967
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      # 基础配置
+      - N8N_HOST=0.0.0.0
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=http
+      - WEBHOOK_URL=http://localhost:8967
+      - GENERIC_TIMEZONE=Asia/Shanghai
+      
+      # 数据库配置 (PostgreSQL)
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_PORT=5432
+      - DB_POSTGRESDB_DATABASE=n8n
+      - DB_POSTGRESDB_USER=n8n_user
+      - DB_POSTGRESDB_PASSWORD=n8n_secure_password_2024
+      - DB_POSTGRESDB_SCHEMA=public
+      
+      # Redis 配置 (队列模式)
+      - QUEUE_BULL_REDIS_HOST=redis
+      - QUEUE_BULL_REDIS_PORT=6379
+      - QUEUE_BULL_REDIS_PASSWORD=redis_secure_password_2024
+      - EXECUTIONS_MODE=queue
+      
+      # 安全配置
+      - N8N_SECURE_COOKIE=false
+      - N8N_METRICS=true
+      - N8N_DIAGNOSTICS_ENABLED=false
+      
+      # Task Runner 配置
+      - N8N_RUNNERS_ENABLED=true
+      - N8N_RUNNERS_MODE=internal
+      
+      # 日志配置
+      - N8N_LOG_LEVEL=info
+      - N8N_LOG_OUTPUT=console
+      
+      # 性能配置
+      - N8N_CONCURRENCY_PRODUCTION_LIMIT=10
+      - EXECUTIONS_DATA_PRUNE=true
+      - EXECUTIONS_DATA_MAX_AGE=168  # 7天
+      
+      # 邮件配置 (可选)
+      # - N8N_EMAIL_MODE=smtp
+      # - N8N_SMTP_HOST=smtp.gmail.com
+      # - N8N_SMTP_PORT=587
+      # - N8N_SMTP_USER=your-email@gmail.com
+      # - N8N_SMTP_PASS=your-app-password
+      # - N8N_SMTP_SENDER=your-email@gmail.com
+      
+    volumes:
+      - n8n_data:/home/node/.n8n
+      - ./custom-nodes:/home/node/.n8n/custom  # 自定义节点目录
+      - ./workflows:/home/node/.n8n/workflows  # 工作流备份目录
+    networks:
+      - n8n_network
+    healthcheck:
+      test: ['CMD-SHELL', 'wget --spider -q http://localhost:5678/healthz || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # n8n Worker (可选 - 用于扩展处理能力)
+  n8n-worker:
+    image: n8nio/n8n:latest
+    platform: linux/arm64
+    container_name: n8n-worker
+    restart: unless-stopped
+    command: worker
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      n8n:
+        condition: service_healthy
+    environment:
+      # 基础配置
+      - GENERIC_TIMEZONE=Asia/Shanghai
+      
+      # 数据库配置
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_PORT=5432
+      - DB_POSTGRESDB_DATABASE=n8n
+      - DB_POSTGRESDB_USER=n8n_user
+      - DB_POSTGRESDB_PASSWORD=n8n_secure_password_2024
+      
+      # Redis 配置
+      - QUEUE_BULL_REDIS_HOST=redis
+      - QUEUE_BULL_REDIS_PORT=6379
+      - QUEUE_BULL_REDIS_PASSWORD=redis_secure_password_2024
+      - EXECUTIONS_MODE=queue
+      - QUEUE_HEALTH_CHECK_ACTIVE=true
+      
+      # Worker 配置
+      - N8N_CONCURRENCY_PRODUCTION_LIMIT=5
+      - N8N_RUNNERS_ENABLED=true
+      - N8N_RUNNERS_MODE=internal
+      
+      # 安全配置
+      - N8N_DIAGNOSTICS_ENABLED=false
+      
+      # 日志配置
+      - N8N_LOG_LEVEL=info
+      - N8N_LOG_OUTPUT=console
+      
+    volumes:
+      - n8n_data:/home/node/.n8n
+    networks:
+      - n8n_network
+    healthcheck:
+      test: ['CMD-SHELL', 'ps aux | grep -v grep | grep n8n || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+# 数据卷
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  n8n_data:
+    driver: local
+
+# 网络
+networks:
+  n8n_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16

--- a/manage-n8n.sh
+++ b/manage-n8n.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+
+# n8n Docker Compose 管理脚本 - Mac M芯片专用
+# 提供完整的 n8n 服务管理功能
+
+set -e
+
+# 配置变量
+COMPOSE_FILE="docker-compose-mac-m1.yml"
+PROJECT_NAME="n8n-mac-m1"
+HOST_PORT="8967"
+
+# 颜色输出
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# 显示帮助信息
+show_help() {
+    echo -e "${BLUE}=== n8n Docker Compose 管理脚本 (Mac M芯片) ===${NC}"
+    echo -e "${CYAN}使用方法: $0 [命令]${NC}"
+    echo ""
+    echo -e "${YELLOW}可用命令:${NC}"
+    echo -e "  ${GREEN}start${NC}     启动所有服务"
+    echo -e "  ${GREEN}stop${NC}      停止所有服务"
+    echo -e "  ${GREEN}restart${NC}   重启所有服务"
+    echo -e "  ${GREEN}status${NC}    查看服务状态"
+    echo -e "  ${GREEN}logs${NC}      查看实时日志"
+    echo -e "  ${GREEN}logs-n8n${NC}  只查看 n8n 日志"
+    echo -e "  ${GREEN}backup${NC}    备份数据库"
+    echo -e "  ${GREEN}restore${NC}   恢复数据库 (需要备份文件)"
+    echo -e "  ${GREEN}update${NC}    更新到最新版本"
+    echo -e "  ${GREEN}clean${NC}     清理未使用的数据"
+    echo -e "  ${GREEN}shell${NC}     进入 n8n 容器 shell"
+    echo -e "  ${GREEN}psql${NC}      连接 PostgreSQL 数据库"
+    echo -e "  ${GREEN}redis${NC}     连接 Redis"
+    echo -e "  ${GREEN}info${NC}      显示系统信息"
+    echo -e "  ${GREEN}help${NC}      显示此帮助信息"
+    echo ""
+    echo -e "${BLUE}访问地址: ${GREEN}http://localhost:${HOST_PORT}${NC}"
+}
+
+# 检查 Docker 和 Docker Compose
+check_dependencies() {
+    if ! command -v docker &> /dev/null; then
+        echo -e "${RED}错误: Docker 未安装${NC}"
+        exit 1
+    fi
+
+    if ! docker info > /dev/null 2>&1; then
+        echo -e "${RED}错误: Docker 未运行${NC}"
+        exit 1
+    fi
+
+    if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+        echo -e "${RED}错误: Docker Compose 未安装${NC}"
+        exit 1
+    fi
+}
+
+# Docker Compose 命令封装
+dc() {
+    if command -v docker-compose &> /dev/null; then
+        docker-compose -f "${COMPOSE_FILE}" -p "${PROJECT_NAME}" "$@"
+    else
+        docker compose -f "${COMPOSE_FILE}" -p "${PROJECT_NAME}" "$@"
+    fi
+}
+
+# 启动服务
+start_services() {
+    echo -e "${BLUE}启动 n8n 服务...${NC}"
+    
+    # 创建必要的目录
+    mkdir -p backups custom-nodes workflows
+    
+    # 启动服务
+    dc up -d
+    
+    echo -e "${YELLOW}等待服务启动...${NC}"
+    sleep 10
+    
+    # 检查服务状态
+    if dc ps | grep -q "Up"; then
+        echo -e "${GREEN}✅ 服务启动成功!${NC}"
+        echo -e "${GREEN}🌐 访问地址: http://localhost:${HOST_PORT}${NC}"
+        echo -e "${CYAN}💡 首次启动可能需要几分钟来初始化数据库${NC}"
+    else
+        echo -e "${RED}❌ 服务启动失败${NC}"
+        dc logs
+    fi
+}
+
+# 停止服务
+stop_services() {
+    echo -e "${YELLOW}停止 n8n 服务...${NC}"
+    dc down
+    echo -e "${GREEN}✅ 服务已停止${NC}"
+}
+
+# 重启服务
+restart_services() {
+    echo -e "${YELLOW}重启 n8n 服务...${NC}"
+    dc restart
+    echo -e "${GREEN}✅ 服务已重启${NC}"
+}
+
+# 查看服务状态
+show_status() {
+    echo -e "${BLUE}=== 服务状态 ===${NC}"
+    dc ps
+    echo ""
+    echo -e "${BLUE}=== 容器资源使用情况 ===${NC}"
+    docker stats --no-stream $(dc ps -q) 2>/dev/null || echo "没有运行的容器"
+}
+
+# 查看日志
+show_logs() {
+    if [ "$1" = "n8n" ]; then
+        echo -e "${BLUE}=== n8n 服务日志 ===${NC}"
+        dc logs -f n8n
+    else
+        echo -e "${BLUE}=== 所有服务日志 ===${NC}"
+        dc logs -f
+    fi
+}
+
+# 备份数据库
+backup_database() {
+    echo -e "${BLUE}备份 PostgreSQL 数据库...${NC}"
+    
+    BACKUP_FILE="backups/n8n_backup_$(date +%Y%m%d_%H%M%S).sql"
+    
+    dc exec -T postgres pg_dump -U n8n_user -d n8n > "${BACKUP_FILE}"
+    
+    if [ $? -eq 0 ]; then
+        echo -e "${GREEN}✅ 数据库备份成功: ${BACKUP_FILE}${NC}"
+    else
+        echo -e "${RED}❌ 数据库备份失败${NC}"
+    fi
+}
+
+# 恢复数据库
+restore_database() {
+    echo -e "${YELLOW}可用的备份文件:${NC}"
+    ls -la backups/*.sql 2>/dev/null || {
+        echo -e "${RED}没有找到备份文件${NC}"
+        return 1
+    }
+    
+    echo -e "${CYAN}请输入要恢复的备份文件名:${NC}"
+    read -r backup_file
+    
+    if [ ! -f "$backup_file" ]; then
+        echo -e "${RED}备份文件不存在: $backup_file${NC}"
+        return 1
+    fi
+    
+    echo -e "${YELLOW}警告: 这将覆盖当前数据库! 确认继续? (y/N)${NC}"
+    read -r confirm
+    
+    if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+        echo -e "${BLUE}恢复数据库...${NC}"
+        dc exec -T postgres psql -U n8n_user -d n8n < "$backup_file"
+        echo -e "${GREEN}✅ 数据库恢复完成${NC}"
+    else
+        echo -e "${YELLOW}操作已取消${NC}"
+    fi
+}
+
+# 更新到最新版本
+update_services() {
+    echo -e "${BLUE}更新 n8n 到最新版本...${NC}"
+    
+    # 先备份
+    backup_database
+    
+    # 拉取最新镜像
+    dc pull
+    
+    # 重启服务
+    dc up -d
+    
+    echo -e "${GREEN}✅ 更新完成${NC}"
+}
+
+# 清理数据
+clean_data() {
+    echo -e "${YELLOW}这将删除未使用的 Docker 镜像和卷${NC}"
+    echo -e "${RED}确认继续? (y/N)${NC}"
+    read -r confirm
+    
+    if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+        docker system prune -f
+        echo -e "${GREEN}✅ 清理完成${NC}"
+    else
+        echo -e "${YELLOW}操作已取消${NC}"
+    fi
+}
+
+# 进入容器 shell
+enter_shell() {
+    echo -e "${BLUE}进入 n8n 容器...${NC}"
+    dc exec n8n /bin/sh
+}
+
+# 连接 PostgreSQL
+connect_psql() {
+    echo -e "${BLUE}连接 PostgreSQL...${NC}"
+    dc exec postgres psql -U n8n_user -d n8n
+}
+
+# 连接 Redis
+connect_redis() {
+    echo -e "${BLUE}连接 Redis...${NC}"
+    dc exec redis redis-cli -a redis_secure_password_2024
+}
+
+# 显示系统信息
+show_info() {
+    echo -e "${BLUE}=== 系统信息 ===${NC}"
+    echo -e "${CYAN}架构:${NC} $(uname -m)"
+    echo -e "${CYAN}操作系统:${NC} $(uname -s)"
+    echo -e "${CYAN}Docker 版本:${NC} $(docker --version)"
+    
+    if command -v docker-compose &> /dev/null; then
+        echo -e "${CYAN}Docker Compose 版本:${NC} $(docker-compose --version)"
+    else
+        echo -e "${CYAN}Docker Compose 版本:${NC} $(docker compose version)"
+    fi
+    
+    echo ""
+    echo -e "${BLUE}=== n8n 配置信息 ===${NC}"
+    echo -e "${CYAN}访问端口:${NC} ${HOST_PORT}"
+    echo -e "${CYAN}项目名称:${NC} ${PROJECT_NAME}"
+    echo -e "${CYAN}配置文件:${NC} ${COMPOSE_FILE}"
+    echo -e "${CYAN}数据库:${NC} PostgreSQL"
+    echo -e "${CYAN}缓存:${NC} Redis"
+    echo -e "${CYAN}平台:${NC} linux/arm64"
+}
+
+# 主函数
+main() {
+    case "${1:-help}" in
+        start)
+            check_dependencies
+            start_services
+            ;;
+        stop)
+            check_dependencies
+            stop_services
+            ;;
+        restart)
+            check_dependencies
+            restart_services
+            ;;
+        status)
+            check_dependencies
+            show_status
+            ;;
+        logs)
+            check_dependencies
+            show_logs
+            ;;
+        logs-n8n)
+            check_dependencies
+            show_logs n8n
+            ;;
+        backup)
+            check_dependencies
+            backup_database
+            ;;
+        restore)
+            check_dependencies
+            restore_database
+            ;;
+        update)
+            check_dependencies
+            update_services
+            ;;
+        clean)
+            check_dependencies
+            clean_data
+            ;;
+        shell)
+            check_dependencies
+            enter_shell
+            ;;
+        psql)
+            check_dependencies
+            connect_psql
+            ;;
+        redis)
+            check_dependencies
+            connect_redis
+            ;;
+        info)
+            show_info
+            ;;
+        help|--help|-h)
+            show_help
+            ;;
+        *)
+            echo -e "${RED}未知命令: $1${NC}"
+            show_help
+            exit 1
+            ;;
+    esac
+}
+
+# 运行主函数
+main "$@"

--- a/run-n8n-mac-m1.sh
+++ b/run-n8n-mac-m1.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# n8n Docker 运行脚本 - 适用于 Mac M芯片
+# 使用端口: 8967 (不常见端口)
+# 作者: 自动生成脚本
+
+set -e
+
+# 配置变量
+CONTAINER_NAME="n8n-workflow"
+IMAGE_NAME="n8nio/n8n:latest"
+HOST_PORT="8967"
+CONTAINER_PORT="5678"
+DATA_DIR="./n8n-data"
+WEBHOOK_URL="http://localhost:${HOST_PORT}"
+
+# 颜色输出
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== n8n Docker 启动脚本 (Mac M芯片专用) ===${NC}"
+echo -e "${YELLOW}端口: ${HOST_PORT}${NC}"
+echo -e "${YELLOW}数据目录: ${DATA_DIR}${NC}"
+
+# 检查Docker是否运行
+if ! docker info > /dev/null 2>&1; then
+    echo -e "${RED}错误: Docker 未运行或未安装${NC}"
+    exit 1
+fi
+
+# 停止并删除现有容器
+if docker ps -a --format 'table {{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo -e "${YELLOW}停止现有容器: ${CONTAINER_NAME}${NC}"
+    docker stop ${CONTAINER_NAME} > /dev/null 2>&1 || true
+    docker rm ${CONTAINER_NAME} > /dev/null 2>&1 || true
+fi
+
+# 创建数据目录
+mkdir -p ${DATA_DIR}
+
+# 设置权限 (Mac M芯片需要)
+if [[ $(uname -m) == "arm64" ]]; then
+    echo -e "${BLUE}检测到 ARM64 架构 (Mac M芯片)${NC}"
+    # 确保数据目录权限正确
+    chmod 755 ${DATA_DIR}
+fi
+
+echo -e "${BLUE}启动 n8n 容器...${NC}"
+
+# 运行Docker容器
+docker run -d \
+    --name ${CONTAINER_NAME} \
+    --platform linux/arm64 \
+    -p ${HOST_PORT}:${CONTAINER_PORT} \
+    -v ${PWD}/${DATA_DIR}:/home/node/.n8n \
+    -e N8N_HOST=0.0.0.0 \
+    -e N8N_PORT=${CONTAINER_PORT} \
+    -e N8N_PROTOCOL=http \
+    -e WEBHOOK_URL=${WEBHOOK_URL} \
+    -e GENERIC_TIMEZONE=Asia/Shanghai \
+    -e N8N_METRICS=true \
+    -e N8N_DIAGNOSTICS_ENABLED=false \
+    -e DB_TYPE=sqlite \
+    -e DB_SQLITE_ENABLE_WAL=true \
+    -e DB_SQLITE_VACUUM_ON_STARTUP=true \
+    -e N8N_RUNNERS_ENABLED=true \
+    -e N8N_RUNNERS_MODE=internal \
+    -e N8N_LOG_LEVEL=info \
+    -e N8N_LOG_OUTPUT=console \
+    --restart unless-stopped \
+    ${IMAGE_NAME}
+
+# 等待容器启动
+echo -e "${YELLOW}等待容器启动...${NC}"
+sleep 5
+
+# 检查容器状态
+if docker ps --format 'table {{.Names}}\t{{.Status}}' | grep -q "^${CONTAINER_NAME}"; then
+    echo -e "${GREEN}✅ n8n 容器启动成功!${NC}"
+    echo -e "${GREEN}🌐 访问地址: http://localhost:${HOST_PORT}${NC}"
+    echo -e "${GREEN}📁 数据目录: ${PWD}/${DATA_DIR}${NC}"
+    echo ""
+    echo -e "${BLUE}常用命令:${NC}"
+    echo -e "  查看容器状态: ${YELLOW}docker ps${NC}"
+    echo -e "  查看日志: ${YELLOW}docker logs ${CONTAINER_NAME}${NC}"
+    echo -e "  停止容器: ${YELLOW}docker stop ${CONTAINER_NAME}${NC}"
+    echo -e "  重启容器: ${YELLOW}docker restart ${CONTAINER_NAME}${NC}"
+    echo ""
+    echo -e "${BLUE}🔧 容器配置:${NC}"
+    echo -e "  - 平台: linux/arm64 (Mac M芯片优化)"
+    echo -e "  - 数据库: SQLite (适合单用户使用)"
+    echo -e "  - 时区: Asia/Shanghai"
+    echo -e "  - 自动重启: 是"
+    echo -e "  - Task Runner: 启用"
+else
+    echo -e "${RED}❌ 容器启动失败${NC}"
+    echo -e "${YELLOW}查看错误日志:${NC}"
+    docker logs ${CONTAINER_NAME}
+    exit 1
+fi

--- a/start-n8n.sh
+++ b/start-n8n.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# n8n 启动选择器 - Mac M芯片专用
+# 提供简单和完整两种部署方案选择
+
+set -e
+
+# 颜色输出
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# 显示欢迎信息
+show_welcome() {
+    clear
+    echo -e "${BLUE}╔══════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║                                                          ║${NC}"
+    echo -e "${BLUE}║         🚀 n8n Docker 启动器 - Mac M芯片专用            ║${NC}"
+    echo -e "${BLUE}║                                                          ║${NC}"
+    echo -e "${BLUE}║         使用端口: ${GREEN}8967${BLUE}                                 ║${NC}"
+    echo -e "${BLUE}║         访问地址: ${GREEN}http://localhost:8967${BLUE}               ║${NC}"
+    echo -e "${BLUE}║                                                          ║${NC}"
+    echo -e "${BLUE}╚══════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+# 检查系统要求
+check_system() {
+    echo -e "${CYAN}正在检查系统要求...${NC}"
+    
+    # 检查架构
+    if [[ $(uname -m) != "arm64" ]]; then
+        echo -e "${YELLOW}⚠️  警告: 未检测到ARM64架构，但脚本将继续运行${NC}"
+    else
+        echo -e "${GREEN}✅ ARM64架构 (Mac M芯片)${NC}"
+    fi
+    
+    # 检查Docker
+    if ! command -v docker &> /dev/null; then
+        echo -e "${RED}❌ Docker 未安装${NC}"
+        echo -e "${YELLOW}请先安装 Docker Desktop for Mac${NC}"
+        exit 1
+    fi
+    
+    if ! docker info > /dev/null 2>&1; then
+        echo -e "${RED}❌ Docker 未运行${NC}"
+        echo -e "${YELLOW}请先启动 Docker Desktop${NC}"
+        exit 1
+    fi
+    
+    echo -e "${GREEN}✅ Docker 运行正常${NC}"
+    
+    # 检查Docker Compose
+    if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+        echo -e "${YELLOW}⚠️  Docker Compose 未找到，但可能仍能使用内置版本${NC}"
+    else
+        echo -e "${GREEN}✅ Docker Compose 可用${NC}"
+    fi
+    
+    echo ""
+    sleep 2
+}
+
+# 显示部署方案对比
+show_comparison() {
+    echo -e "${BLUE}=== 📚 部署方案对比 ===${NC}"
+    echo ""
+    printf "%-20s %-20s %-20s\n" "特性" "简单方案" "完整方案"
+    echo -e "${CYAN}$(printf '%-60s' | tr ' ' '─')${NC}"
+    printf "%-20s %-20s %-20s\n" "数据库" "SQLite" "PostgreSQL"
+    printf "%-20s %-20s %-20s\n" "缓存" "无" "Redis"
+    printf "%-20s %-20s %-20s\n" "Worker支持" "无" "支持"
+    printf "%-20s %-20s %-20s\n" "队列模式" "无" "支持"
+    printf "%-20s %-20s %-20s\n" "扩展性" "有限" "高"
+    printf "%-20s %-20s %-20s\n" "资源占用" "低" "中等"
+    printf "%-20s %-20s %-20s\n" "适用场景" "个人/测试" "生产/团队"
+    printf "%-20s %-20s %-20s\n" "启动时间" "快" "稍慢"
+    echo ""
+}
+
+# 选择部署方案
+choose_deployment() {
+    while true; do
+        echo -e "${YELLOW}请选择部署方案:${NC}"
+        echo ""
+        echo -e "  ${GREEN}1)${NC} 🏃 简单方案 - 单容器 + SQLite"
+        echo -e "     ${CYAN}• 快速启动，适合个人使用和测试${NC}"
+        echo -e "     ${CYAN}• 资源占用少，配置简单${NC}"
+        echo ""
+        echo -e "  ${GREEN}2)${NC} 🏢 完整方案 - 多容器 + PostgreSQL + Redis"
+        echo -e "     ${CYAN}• 生产级别，支持高并发和队列${NC}"
+        echo -e "     ${CYAN}• 支持Worker扩展和数据备份${NC}"
+        echo ""
+        echo -e "  ${GREEN}3)${NC} 📖 查看详细文档"
+        echo ""
+        echo -e "  ${GREEN}0)${NC} 退出"
+        echo ""
+        
+        read -p "$(echo -e ${CYAN}请输入选择 [1-3,0]: ${NC})" choice
+        
+        case $choice in
+            1)
+                deploy_simple
+                break
+                ;;
+            2)
+                deploy_full
+                break
+                ;;
+            3)
+                show_documentation
+                ;;
+            0)
+                echo -e "${YELLOW}再见! 👋${NC}"
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}❌ 无效选择，请输入 1、2、3 或 0${NC}"
+                echo ""
+                ;;
+        esac
+    done
+}
+
+# 简单部署
+deploy_simple() {
+    echo ""
+    echo -e "${BLUE}=== 🏃 启动简单方案 ===${NC}"
+    echo -e "${CYAN}正在使用单容器 + SQLite 模式...${NC}"
+    echo ""
+    
+    if [ ! -f "run-n8n-mac-m1.sh" ]; then
+        echo -e "${RED}❌ 找不到 run-n8n-mac-m1.sh 脚本${NC}"
+        exit 1
+    fi
+    
+    chmod +x run-n8n-mac-m1.sh
+    ./run-n8n-mac-m1.sh
+    
+    show_success_simple
+}
+
+# 完整部署
+deploy_full() {
+    echo ""
+    echo -e "${BLUE}=== 🏢 启动完整方案 ===${NC}"
+    echo -e "${CYAN}正在使用多容器 + PostgreSQL + Redis 模式...${NC}"
+    echo ""
+    
+    if [ ! -f "manage-n8n.sh" ]; then
+        echo -e "${RED}❌ 找不到 manage-n8n.sh 脚本${NC}"
+        exit 1
+    fi
+    
+    if [ ! -f "docker-compose-mac-m1.yml" ]; then
+        echo -e "${RED}❌ 找不到 docker-compose-mac-m1.yml 配置文件${NC}"
+        exit 1
+    fi
+    
+    chmod +x manage-n8n.sh
+    ./manage-n8n.sh start
+    
+    show_success_full
+}
+
+# 显示成功信息 - 简单方案
+show_success_simple() {
+    echo ""
+    echo -e "${GREEN}🎉 简单方案启动成功!${NC}"
+    echo ""
+    echo -e "${BLUE}📌 访问信息:${NC}"
+    echo -e "  🌐 Web界面: ${GREEN}http://localhost:8967${NC}"
+    echo -e "  📂 数据目录: ${CYAN}./n8n-data${NC}"
+    echo -e "  🗄️  数据库: ${CYAN}SQLite (内置)${NC}"
+    echo ""
+    echo -e "${BLUE}💡 常用命令:${NC}"
+    echo -e "  查看状态: ${YELLOW}docker ps${NC}"
+    echo -e "  查看日志: ${YELLOW}docker logs n8n-workflow${NC}"
+    echo -e "  停止服务: ${YELLOW}docker stop n8n-workflow${NC}"
+    echo -e "  重启服务: ${YELLOW}docker restart n8n-workflow${NC}"
+    echo ""
+}
+
+# 显示成功信息 - 完整方案
+show_success_full() {
+    echo ""
+    echo -e "${GREEN}🎉 完整方案启动成功!${NC}"
+    echo ""
+    echo -e "${BLUE}📌 访问信息:${NC}"
+    echo -e "  🌐 Web界面: ${GREEN}http://localhost:8967${NC}"
+    echo -e "  🗄️  数据库: ${CYAN}PostgreSQL${NC}"
+    echo -e "  🔄 缓存: ${CYAN}Redis${NC}"
+    echo -e "  👷 Worker: ${CYAN}已启用${NC}"
+    echo ""
+    echo -e "${BLUE}💡 管理命令:${NC}"
+    echo -e "  查看状态: ${YELLOW}./manage-n8n.sh status${NC}"
+    echo -e "  查看日志: ${YELLOW}./manage-n8n.sh logs${NC}"
+    echo -e "  备份数据: ${YELLOW}./manage-n8n.sh backup${NC}"
+    echo -e "  停止服务: ${YELLOW}./manage-n8n.sh stop${NC}"
+    echo -e "  获取帮助: ${YELLOW}./manage-n8n.sh help${NC}"
+    echo ""
+}
+
+# 显示文档
+show_documentation() {
+    echo ""
+    echo -e "${BLUE}=== 📖 文档和资源 ===${NC}"
+    echo ""
+    echo -e "${CYAN}📄 本地文档:${NC}"
+    echo -e "  • README-Mac-M1-Docker.md - 完整使用指南"
+    echo ""
+    echo -e "${CYAN}🌐 在线资源:${NC}"
+    echo -e "  • n8n官方文档: https://docs.n8n.io/"
+    echo -e "  • Docker官方文档: https://docs.docker.com/"
+    echo -e "  • n8n社区论坛: https://community.n8n.io/"
+    echo ""
+    echo -e "${CYAN}💡 快速提示:${NC}"
+    echo -e "  • 首次启动可能需要3-5分钟下载镜像"
+    echo -e "  • 如果8967端口被占用，可修改脚本中的端口设置"
+    echo -e "  • 建议定期备份数据（完整方案支持自动备份）"
+    echo ""
+    
+    read -p "$(echo -e ${YELLOW}按回车键返回主菜单...${NC})" 
+    echo ""
+}
+
+# 主函数
+main() {
+    show_welcome
+    check_system
+    show_comparison
+    choose_deployment
+}
+
+# 运行主函数
+main "$@"


### PR DESCRIPTION
A comprehensive Docker setup for n8n on Mac M-chip was created, exposing the service on the uncommon port `8967`.

New files include:
*   `.env.example`: A template for environment variables, including the new port and database credentials.
*   `QUICK-START.md` and `README-Mac-M1-Docker.md`: Documentation for setup and usage.
*   `run-n8n-mac-m1.sh`: A script for a simple, single-container n8n deployment using SQLite. It explicitly maps `8967:5678` and sets `--platform linux/arm64` for M-chip compatibility.
*   `docker-compose-mac-m1.yml`: Defines a full multi-container n8n stack with PostgreSQL and Redis, also mapping `8967:5678` and specifying `platform: linux/arm64`.
*   `manage-n8n.sh`: A utility script to manage the full Docker Compose stack (start, stop, backup, update).
*   `start-n8n.sh`: An interactive script to guide users through choosing between the simple and full deployment options.

The changes provide flexible deployment solutions optimized for ARM64 architecture, ensuring an easily configurable and managed n8n instance on Mac M-chip devices.